### PR TITLE
Add Java 17 build compatibility and fix macOS Silicon Docker builds

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,7 @@
+--add-opens java.base/java.lang=ALL-UNNAMED
+--add-opens java.base/java.util=ALL-UNNAMED
+--add-opens java.base/java.io=ALL-UNNAMED
+--add-opens java.base/java.net=ALL-UNNAMED
+--add-opens java.base/java.nio=ALL-UNNAMED
+--add-opens java.base/java.text=ALL-UNNAMED
+--add-opens java.base/sun.nio.ch=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.14.0</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -121,7 +121,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifest>
@@ -137,14 +137,14 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.18.1</version>
+        <version>3.1.2</version>
         <configuration>
           <skipTests>true</skipTests>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.6.0</version>
         <configuration>
           <archive>
             <manifest>
@@ -222,7 +222,7 @@
         <plugin>
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>
-          <version>0.28.0</version>
+          <version>0.46.0</version>
           <configuration>
             <images>
               <image>


### PR DESCRIPTION
- Upgrade maven-compiler-plugin to 3.14.0 with Java 1.8 target for compatibility with Java 8-11-17
- Upgrade docker-maven-plugin to 0.46.0 to fix builds on macOS Silicon/ARM64
- Update Maven plugins to modern versions for better Java 17 support:
  - maven-jar-plugin: 3.0.2 -> 3.3.0
  - maven-surefire-plugin: 2.18.1 -> 3.1.2
  - maven-assembly-plugin: 2.6 -> 3.6.0
- Add .mvn/jvm.config with jvm parameters to avoid the "module java.base does not "opens java.lang" to unnamed module" error

This enables the ETS to build successfully with Java 11 and 17.
---

This is required for the following pull request to be able to run the WMSTS CITE  with Java 17

- https://github.com/geoserver/geoserver/pull/8573